### PR TITLE
feat: bump rfl to integrate plotly-based clinvar landscape (#430)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "luxon": "^3.4.4",
         "mitt": "^3.0.1",
         "pinia": "^2.1.7",
+        "plotly.js-dist": "^2.29.0",
         "title-case": "^4.3.1",
         "unplugin-fonts": "^1.1.1",
         "vega": "^5.26.1",
@@ -18255,6 +18256,11 @@
         "mlly": "^1.2.0",
         "pathe": "^1.1.0"
       }
+    },
+    "node_modules/plotly.js-dist": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-2.29.0.tgz",
+      "integrity": "sha512-RwVeITXolsqZEQJfWIGJB7EABaKAQo9uf+Bz+DICftY2o4idRoD9kOmxQ5YjpbifISBf9udFhYA5FY/vINlK+g=="
     },
     "node_modules/polished": {
       "version": "4.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "luxon": "^3.4.4",
     "mitt": "^3.0.1",
     "pinia": "^2.1.7",
+    "plotly.js-dist": "^2.29.0",
     "title-case": "^4.3.1",
     "unplugin-fonts": "^1.1.1",
     "vega": "^5.26.1",

--- a/frontend/src/lib/modulesDeclarations.d.ts
+++ b/frontend/src/lib/modulesDeclarations.d.ts
@@ -3,3 +3,6 @@ declare module 'igv'
 
 // Declare vue-matomo module
 declare module 'vue-matomo'
+
+// Declare plotly.js-dist module
+declare module 'plotly.js-dist'


### PR DESCRIPTION
rfl == reev-frontend-lib
