### PR TITLE
fix: update Viguno base URL to include /api/v1 to prevent 404 errors

### DIFF
--- a/frontend/src/plugins/reevFrontendLib.ts
+++ b/frontend/src/plugins/reevFrontendLib.ts
@@ -3,7 +3,7 @@ import { urlConfig } from '@bihealth/reev-frontend-lib/lib/urlConfig'
 export function setupBackendUrls() {
   urlConfig.baseUrlAnnonars = '/internal/proxy/annonars'
   urlConfig.baseUrlMehari = '/internal/proxy/mehari'
-  urlConfig.baseUrlViguno = '/internal/proxy/viguno'
+  urlConfig.baseUrlViguno = '/internal/proxy/viguno/api/v1'
   urlConfig.baseUrlNginx = '/internal/proxy/nginx'
   urlConfig.baseUrlPubtator = '/internal/remote/pubtator3-api'
   urlConfig.baseUrlCadaPrio = '/internal/proxy/cada-prio'

--- a/frontend/src/stores/terms/store.ts
+++ b/frontend/src/stores/terms/store.ts
@@ -23,7 +23,7 @@ export const useTermsStore = defineStore('terms', () => {
    */
   const fetchHpoTerms = async (query: string) => {
     storeState.value = StoreState.Loading
-    const vigunoClient = new VigunoClient()
+    const vigunoClient = new VigunoClient('/internal/proxy/viguno/api/v1')
 
     // Regular expression to match "HPO:1234567" or "1234567"
     const hpoIdPattern = /^(HP:)?\d{7}$/
@@ -52,7 +52,7 @@ export const useTermsStore = defineStore('terms', () => {
    */
   const fetchOmimTerms = async (query: string) => {
     storeState.value = StoreState.Loading
-    const vigunoClient = new VigunoClient()
+    const vigunoClient = new VigunoClient('/internal/proxy/viguno/api/v1')
 
     // Regular expression to match "OMIM:1234567" or "1234567"
     const omimIdPattern = /^(OMIM:)?\d{6}$/

--- a/frontend/src/vitest.setup.ts
+++ b/frontend/src/vitest.setup.ts
@@ -13,7 +13,7 @@ window.ResizeObserver = window.ResizeObserver || ResizeObserverStub
 // Define base URLs for API calls in tests.
 urlConfig.baseUrlAnnonars = '/internal/proxy/annonars'
 urlConfig.baseUrlMehari = '/internal/proxy/mehari'
-urlConfig.baseUrlViguno = '/internal/proxy/viguno'
+urlConfig.baseUrlViguno = '/internal/proxy/viguno/api/v1'
 urlConfig.baseUrlNginx = '/internal/proxy/nginx'
 urlConfig.baseUrlPubtator = '/internal/remote/pubtator3-api'
 urlConfig.baseUrlCadaPrio = '/internal/proxy/cada-prio'


### PR DESCRIPTION
### Description

This pull request fixes the missing `/api/v1` segment in the Viguno base URL on the frontend configuration.

Currently, frontend requests to Viguno lack the `/api/v1` prefix, causing 404 Not Found errors when accessing Viguno endpoints via the proxy.

Updating the base URL to include `/api/v1` ensures the frontend requests are routed correctly to Viguno's API.

### Related Issue

Fixes #1182

### Motivation and Context

- Frontend was sending requests like `/internal/proxy/viguno/hpo/genes?...`  
- Viguno expects `/internal/proxy/viguno/api/v1/hpo/genes?...`  
- Manual curl tests confirm only URLs with `/api/v1` return valid data.
